### PR TITLE
12_ログイン関連ページのスタイルの修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,9 @@ gem 'rails-i18n'
 
 gem 'devise'
 
+gem 'devise-i18n'
+gem 'devise-bootstrap-views'
+
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,9 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    devise-bootstrap-views (1.1.0)
+    devise-i18n (1.9.1)
+      devise (>= 4.7.1)
     erubi (1.9.0)
     ffi (1.12.2)
     formtastic (3.1.5)
@@ -257,6 +260,8 @@ DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
   devise
+  devise-bootstrap-views
+  devise-i18n
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,1 +1,7 @@
 @import "bootstrap/scss/bootstrap";
+
+.container-login {
+  @extend .container-fluid;
+  max-width: 576px;
+  padding: 2rem;
+}

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,0 +1,16 @@
+<h1><%= t('.resend_confirmation_instructions') %></h1>
+
+<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+  <%= bootstrap_devise_error_messages! %>
+
+  <div class="form-group">
+    <%= f.label :email %>
+    <%= f.email_field :email, autofocus: true, autocomplete: 'email', value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), class: 'form-control' %>
+  </div>
+
+  <div class="form-group">
+    <%= f.submit t('.resend_confirmation_instructions'), class: 'btn btn-primary' %>
+  </div>
+<% end %>
+
+<%= render 'devise/shared/links' %>

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,0 +1,5 @@
+<p><%= t('.greeting', recipient: @email) %></p>
+
+<p><%= t('.instruction') %></p>
+
+<p><%= link_to t('.action'), confirmation_url(@resource, confirmation_token: @token) %></p>

--- a/app/views/devise/mailer/email_changed.html.erb
+++ b/app/views/devise/mailer/email_changed.html.erb
@@ -1,0 +1,7 @@
+<p><%= t('.greeting', recipient: @email) %></p>
+
+<% if @resource.try(:unconfirmed_email?) %>
+  <p><%= t('.message', email: @resource.unconfirmed_email) %></p>
+<% else %>
+  <p><%= t('.message', email: @resource.email) %></p>
+<% end %>

--- a/app/views/devise/mailer/password_change.html.erb
+++ b/app/views/devise/mailer/password_change.html.erb
@@ -1,0 +1,3 @@
+<p><%= t('.greeting', recipient: @resource.email) %></p>
+
+<p><%= t('.message') %></p>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,0 +1,8 @@
+<p><%= t('.greeting', recipient: @resource.email) %></p>
+
+<p><%= t('.instruction') %></p>
+
+<p><%= link_to t('.action'), edit_password_url(@resource, reset_password_token: @token) %></p>
+
+<p><%= t('.instruction_2') %></p>
+<p><%= t('.instruction_3') %></p>

--- a/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/app/views/devise/mailer/unlock_instructions.html.erb
@@ -1,0 +1,7 @@
+<p><%= t('.greeting', recipient: @resource.email) %></p>
+
+<p><%= t('.message') %></p>
+
+<p><%= t('.instruction') %></p>
+
+<p><%= link_to t('.action'), unlock_url(@resource, unlock_token: @token) %></p>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,0 +1,26 @@
+<h1><%= t('.change_your_password') %></h1>
+
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+  <%= bootstrap_devise_error_messages! %>
+  <%= f.hidden_field :reset_password_token %>
+
+  <div class="form-group">
+    <%= f.label :password, t('.new_password') %>
+    <%= f.password_field :password, autofocus: true, class: 'form-control'  %>
+
+    <% if @minimum_password_length %>
+      <small class="form-text text-muted"><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></small>
+    <% end %>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :password_confirmation, t('.confirm_new_password') %>
+    <%= f.password_field :password_confirmation, autocomplete: 'off', class: 'form-control'  %>
+  </div>
+
+  <div class="form-group">
+    <%= f.submit t('.change_my_password'), class: 'btn btn-primary' %>
+  </div>
+<% end %>
+
+<%= render 'devise/shared/links' %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,0 +1,17 @@
+<div class="container-login">
+<h1><%= t('.forgot_your_password') %></h1>
+
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+
+  <div class="form-group">
+    <%= f.label :email %>
+    <%= f.email_field :email, autofocus: true, autocomplete: 'email', class: 'form-control' %>
+  </div>
+
+  <div class="form-group">
+    <%= f.submit t('.send_me_reset_password_instructions'), class: 'btn btn-primary' %>
+  </div>
+<% end %>
+
+<%= render 'devise/shared/links' %>
+</div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,0 +1,37 @@
+<h1><%= t('.title', resource: resource_name.to_s.humanize) %></h1>
+
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+<%= bootstrap_devise_error_messages! %>
+
+<div class="form-group">
+  <%= f.label :email %>
+  <%= f.email_field :email, autofocus: true, autocomplete: 'email', class: 'form-control' %>
+</div>
+
+<div class="form-group">
+  <%= f.label :password %>
+  <%= f.password_field :password, autocomplete: 'new-password', class: 'form-control' %>
+
+  <small class="form-text text-muted"><%= t('.leave_blank_if_you_don_t_want_to_change_it') %></small>
+</div>
+
+<div class="form-group">
+  <%= f.label :password_confirmation %>
+  <%= f.password_field :password_confirmation, autocomplete: 'new-password', class: 'form-control'  %>
+</div>
+
+<div class="form-group">
+  <%= f.label :current_password %>
+  <%= f.password_field :current_password, autocomplete: 'current-password', class: 'form-control' %>
+
+  <small class="form-text text-muted"><%= t('.we_need_your_current_password_to_confirm_your_changes') %></small>
+</div>
+
+<div class="form-group">
+  <%= f.submit t('.update'), class: 'btn btn-primary' %>
+</div>
+<% end %>
+
+<p><%= t('.unhappy') %>? <%= link_to t('.cancel_my_account'), registration_path(resource_name), data: { confirm: t('.are_you_sure') }, method: :delete %>.</p>
+
+<%= link_to t('.back'), :back %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,0 +1,31 @@
+<div class="container-login">
+<h1><%= t('.sign_up') %></h1>
+
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+
+  <div class="form-group">
+    <%= f.label :email %>
+    <%= f.email_field :email, autofocus: true, autocomplete: 'email', class: 'form-control' %>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :password %>
+    <%= f.password_field :password, autocomplete: 'current-password', class: 'form-control' %>
+
+    <% if @minimum_password_length %>
+      <small class="form-text text-muted"><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></small>
+    <% end %>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :password_confirmation %>
+    <%= f.password_field :password_confirmation, autocomplete: 'current-password', class: 'form-control' %>
+  </div>
+
+  <div class="form-group">
+    <%= f.submit t('.sign_up'), class: 'btn btn-primary' %>
+  </div>
+<% end %>
+
+<%= render 'devise/shared/links' %>
+</div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,0 +1,30 @@
+<div class="container-login">
+<h1><%= t('.sign_in') %></h1>
+
+<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+  <div class="form-group">
+    <%= f.label :email %>
+    <%= f.email_field :email, autofocus: true, autocomplete: 'email', class: 'form-control' %>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :password %>
+    <%= f.password_field :password, autocomplete: 'current-password', class: 'form-control' %>
+  </div>
+
+  <% if devise_mapping.rememberable? %>
+    <div class="form-group form-check">
+      <%= f.check_box :remember_me, class: 'form-check-input' %>
+      <%= f.label :remember_me, class: 'form-check-label' do %>
+        <%= resource.class.human_attribute_name('remember_me') %>
+      <% end %>
+    </div>
+  <% end %>
+
+  <div class="form-group">
+    <%= f.submit  t('.sign_in'), class: 'btn btn-primary' %>
+  </div>
+<% end %>
+
+<%= render 'devise/shared/links' %>
+</div>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,0 +1,15 @@
+<% if resource.errors.any? %>
+  <div id="error_explanation">
+    <h2>
+      <%= I18n.t("errors.messages.not_saved",
+                 count: resource.errors.count,
+                 resource: resource.class.model_name.human.downcase)
+       %>
+    </h2>
+    <ul>
+      <% resource.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,0 +1,27 @@
+<div class="form-group">
+  <%- if controller_name != 'sessions' %>
+    <%= link_to t(".sign_in"), new_session_path(resource_name) %><br />
+  <% end -%>
+
+  <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+    <%= link_to t(".sign_up"), new_registration_path(resource_name) %><br />
+  <% end -%>
+
+  <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+    <%= link_to t(".forgot_your_password"), new_password_path(resource_name) %><br />
+  <% end -%>
+
+  <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+    <%= link_to t('.didn_t_receive_confirmation_instructions'), new_confirmation_path(resource_name) %><br />
+  <% end -%>
+
+  <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
+    <%= link_to t('.didn_t_receive_unlock_instructions'), new_unlock_path(resource_name) %><br />
+  <% end -%>
+
+  <%- if devise_mapping.omniauthable? %>
+    <%- resource_class.omniauth_providers.each do |provider| %>
+      <%= link_to t('.sign_in_with_provider', provider: OmniAuth::Utils.camelize(provider)), omniauth_authorize_path(resource_name, provider) %><br />
+    <% end -%>
+  <% end -%>
+</div>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,0 +1,16 @@
+<h1><%= t('.resend_unlock_instructions') %></h1>
+
+<%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
+  <%= bootstrap_devise_error_messages! %>
+
+  <div class="form-group">
+    <%= f.label :email %>
+    <%= f.email_field :email, autofocus: true, autocomplete: 'email', class: 'form-control' %>
+  </div>
+
+  <div class="form-group">
+    <%= f.submit t('.resend_unlock_instructions'), class: 'btn btn-primary'%>
+  </div>
+<% end %>
+
+<%= render 'devise/shared/links' %>


### PR DESCRIPTION
## 作業内容
- それそれのページを日本語化
- ```rails g devise:i18n:views```を使い多言語対応のビューファイルを作成
- スタイルを中央に寄せ、幅の最大値の指定

## 参考資料
[Deviseでログイン機能を追加・日本語化・Bootstrap4適用まで](https://qiita.com/take18k_tech/items/a36d77316e32a6696205)