### PR TITLE
15_AWSテキスト教材一覧ページの実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,7 +3,7 @@
 .alert-notice {
     @extend .alert-info;
   }
-  
+
   .alert-alert {
     @extend .alert-danger;
   }
@@ -14,3 +14,18 @@
   padding: 2rem;
 }
 
+.container p {
+  width: 680px;
+  margin: 0 auto;
+  padding-bottom: 15px;
+}
+
+.table {
+  margin: auto;
+  width: 65%;
+  max-width: 65%;
+}
+
+table .w-1 {
+  width: 10%;
+}

--- a/app/controllers/aws_texts_controller.rb
+++ b/app/controllers/aws_texts_controller.rb
@@ -1,0 +1,6 @@
+class AwsTextsController < ApplicationController
+
+  def index
+    @awstexts = AwsText.all
+  end
+end

--- a/app/views/aws_texts/index.html.erb
+++ b/app/views/aws_texts/index.html.erb
@@ -1,0 +1,23 @@
+<div class="container">
+  <div class="text-center">
+    <h2>AWS講座</h2>
+  </div>
+  <p>注意！！！：AWSのEC2やRDSは有料サービスとなります。無駄な料金を請求されないためにも、不要なインスタンスは停止・削除をしてください。</p>
+
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead class="aws-table-head text-black">
+        <tr>
+          <th class="w-1">No.</th>
+          <th class="w-5">内容</th>
+        </tr>
+      </thead>
+      <% @awstexts.each.with_index(1) do |awstext, i| %>
+      <tr>
+        <td><%= "#{i}" %></td>
+        <td><%= awstext.title %></td>
+      </tr>
+      <% end %>
+    </table>
+  </div>
+</div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -19,7 +19,7 @@
       </li>
 
       <li class="nav-item active">
-        <a class="nav-link" href="#">AWS講座</a>
+        <a class="nav-link" href="aws_texts">AWS講座</a>
       </li>
 
       <li class="nav-item active">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,6 @@ Rails.application.routes.draw do
   devise_for :admin_users, ActiveAdmin::Devise.config
   ActiveAdmin.routes(self)
   root to: "movies#index"
+  
+  resources :aws_texts, only: [:index]
 end


### PR DESCRIPTION
## 作業内容
- AWSページの作成
- bootstrapを使用しスタイルも似るように作成
- ナビバーのAWS講座リンクが機能するように設定